### PR TITLE
Extend LVM brick functionality

### DIFF
--- a/cinder/tests/brick/fake_lvm.py
+++ b/cinder/tests/brick/fake_lvm.py
@@ -24,6 +24,15 @@ class FakeBrickLVM(object):
         self.vg_free_space = '5.00'
         self.vg_name = vg_name
 
+    def activate_vg(self):
+        pass
+
+    def deactivate_vg(self):
+        pass
+
+    def destroy_vg(self):
+        pass
+
     def supports_thin_provisioning():
         return False
 
@@ -64,4 +73,10 @@ class FakeBrickLVM(object):
         pass
 
     def rename_volume(self, lv_name, new_name):
+        pass
+
+    def pv_resize(self, pv_name, new_size_str):
+        pass
+
+    def extend_thin_pool(self):
         pass

--- a/cinder/tests/brick/test_brick_lvm.py
+++ b/cinder/tests/brick/test_brick_lvm.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import mock
 import mox
 from oslo.concurrency import processutils
 
@@ -119,6 +120,14 @@ class BrickLvmTestCase(test.TestCase):
         elif 'lvcreate, -T, -V, ' in cmd_string:
             pass
         elif 'lvcreate, --name, ' in cmd_string:
+            pass
+        elif 'vgremove, -f, ' in cmd_string:
+            pass
+        elif 'pvresize, ' in cmd_string:
+            pass
+        elif 'lvextend, ' in cmd_string:
+            pass
+        elif 'lvchange, ' in cmd_string:
             pass
         else:
             raise AssertionError('unexpected command called: %s' % cmd_string)
@@ -284,3 +293,71 @@ class BrickLvmTestCase(test.TestCase):
 
     def test_get_mirrored_available_capacity(self):
         self.assertEqual(self.vg.vg_mirror_free_space(1), 2.0)
+
+    def test_activate_vg(self):
+        executor = mock.MagicMock()
+        self.vg.set_execute(executor)
+        self.vg.activate_vg()
+        executor.assert_called_once_with('vgchange', '-ay',
+                                         self.configuration.volume_group_name,
+                                         root_helper=self.vg._root_helper,
+                                         run_as_root=True)
+
+    def test_deactivate_vg(self):
+        executor = mock.MagicMock()
+        self.vg.set_execute(executor)
+        self.vg.deactivate_vg()
+        executor.assert_called_once_with('vgchange', '-an',
+                                         self.configuration.volume_group_name,
+                                         root_helper=self.vg._root_helper,
+                                         run_as_root=True)
+
+    def test_destroy_vg(self):
+        executor = mock.MagicMock()
+        self.vg.set_execute(executor)
+        self.vg.destroy_vg()
+        executor.assert_called_once_with('vgremove', '-f',
+                                         self.configuration.volume_group_name,
+                                         root_helper=self.vg._root_helper,
+                                         run_as_root=True)
+
+    def test_pv_resize(self):
+        executor = mock.MagicMock()
+        self.vg.set_execute(executor)
+        self.vg.pv_resize('fake-pv', '50G')
+        executor.assert_called_once_with('pvresize',
+                                         '--setphysicalvolumesize',
+                                         '50G', 'fake-pv',
+                                         root_helper=self.vg._root_helper,
+                                         run_as_root=True)
+
+    def test_extend_thin_pool_nothin(self):
+        executor =\
+            mock.MagicMock(side_effect=Exception('Unexpected call to execute'))
+        self.vg.set_execute(executor)
+        thin_calc =\
+            mock.MagicMock(
+                side_effect=
+                Exception('Unexpected call to _calculate_thin_pool_size'))
+        self.vg._calculate_thin_pool_size = thin_calc
+        self.vg.extend_thin_pool()
+
+    def test_extend_thin_pool_thin(self):
+        self.stubs.Set(processutils, 'execute', self.fake_execute)
+        self.thin_vg = brick.LVM(self.configuration.volume_group_name,
+                                 'sudo',
+                                 False, None,
+                                 'thin',
+                                 self.fake_execute)
+        self.assertTrue(self.thin_vg.supports_thin_provisioning('sudo'))
+        self.thin_vg.update_volume_group_info = mock.MagicMock()
+        with mock.patch('oslo.concurrency.processutils.execute'):
+            executor = mock.MagicMock()
+            self.thin_vg._execute = executor
+            self.thin_vg.extend_thin_pool()
+            executor.assert_called_once_with('lvextend',
+                                             '-L', '9.5g',
+                                             'fake-vg/fake-vg-pool',
+                                             root_helper=self.vg._root_helper,
+                                             run_as_root=True)
+            self.thin_vg.update_volume_group_info.assert_called_once_with()

--- a/etc/cinder/rootwrap.d/volume.filters
+++ b/etc/cinder/rootwrap.d/volume.filters
@@ -14,6 +14,19 @@ vgs: EnvFilter, env, root, LC_ALL=C, vgs
 lvs: EnvFilter, env, root, LC_ALL=C, lvs
 lvdisplay: EnvFilter, env, root, LC_ALL=C, lvdisplay
 
+# cinder/brick/local_dev/lvm.py: 'pvresize', '--setphysicalvolumesize', sizestr, pvname
+pvresize: CommandFilter, pvresize, root
+
+# cinder/brick/local_dev/lvm.py: 'vgcreate', vg_name, pv_list
+vgcreate: CommandFilter, vgcreate, root
+
+# cinder/brick/local_dev/lvm.py: 'vgremove', '-f', vgname
+vgremove: CommandFilter, vgremove, root
+
+# cinder/brick/local_dev/lvm.py: 'vgchange', '-an', vgname
+# cinder/brick/local_dev/lvm.py: 'vgchange', '-ay', vgname
+vgchange: CommandFilter, vgchange, root
+
 # cinder/volume/driver.py: 'lvcreate', '-L', sizestr, '-n', volume_name,..
 # cinder/volume/driver.py: 'lvcreate', '-L', ...
 lvcreate: CommandFilter, lvcreate, root
@@ -28,6 +41,7 @@ lvremove: CommandFilter, lvremove, root
 lvrename: CommandFilter, lvrename, root
 
 # cinder/volume/driver.py: 'lvextend', '-L' '%(new_size)s', '%(lv_name)s' ...
+# cinder/volume/driver.py: 'lvextend', '-L' '%(new_size)s', '%(thin_pool)s' ...
 lvextend: CommandFilter, lvextend, root
 
 # cinder/brick/local_dev/lvm.py: 'lvchange -a y -K <lv>'


### PR DESCRIPTION
This patch adds some new methods to the LVM brick:
- VG activation
- VG deactivation
- VG removal
- PV resizing
- Thinpool extension

Change-Id: I9070eb5557b5a0ccc0563785f22e5fff7ad332f8
